### PR TITLE
adding AV_STATUS_SNS_SUBJECT_TEMPLATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ the table below for reference.
 | AV_STATUS_SNS_ARN | SNS topic ARN to publish scan results (optional) | | No |
 | AV_STATUS_SNS_PUBLISH_CLEAN | Publish AV_STATUS_CLEAN results to AV_STATUS_SNS_ARN | True | No |
 | AV_STATUS_SNS_PUBLISH_INFECTED | Publish AV_STATUS_INFECTED results to AV_STATUS_SNS_ARN | True | No |
+| AV_STATUS_SNS_SUBJECT_TEMPLATE | Template for SNS Subject. You can use a placeholder `{status}` which will be replaced with `AV_STATUS_CLEAN` or `AV_STATUS_INFECTED`. Maximum length of subject is 100 characters. | | No |
 | AV_TIMESTAMP_METADATA | The tag/metadata name representing file's scan time | av-timestamp | No |
 | CLAMAVLIB_PATH | Path to ClamAV library files | ./bin | No |
 | CLAMSCAN_PATH | Path to ClamAV clamscan binary | ./bin/clamscan | No |

--- a/scan.py
+++ b/scan.py
@@ -280,7 +280,7 @@ def lambda_handler(event, context):
             scan_result,
             scan_signature,
             result_time,
-            subject=os.environ.get("AV_STATUS_SNS_SUBJECT_TEMPLATE", None),
+            subject_template=os.environ.get("AV_STATUS_SNS_SUBJECT_TEMPLATE", None),
         )
 
     metrics.send(


### PR DESCRIPTION
Support a new environment variable `AV_STATUS_SNS_SUBJECT_TEMPLATE` which allows specification of a template with a placeholder `{status}` which will be replaced with the status (CLEAN or INFECTED by default).